### PR TITLE
sitemap.xml: Don't prefix absolute Uri

### DIFF
--- a/core/Piranha.AspNetCore/SitemapMiddleware.cs
+++ b/core/Piranha.AspNetCore/SitemapMiddleware.cs
@@ -101,13 +101,14 @@ namespace Piranha.AspNetCore
         private async Task<List<Url>> GetPageUrlsAsync(IApi api, Piranha.Models.SitemapItem item, string baseUrl)
         {
             var urls = new List<Url>();
-
+            
             if (item.Published.HasValue && item.Published.Value <= DateTime.Now)
             {
                 urls.Add(new Url
                 {
                     ChangeFrequency = ChangeFrequency.Daily,
-                    Location = baseUrl + item.Permalink,
+                    // If the Permalink contains an absolute Uri (e.g. redirection), don't prefix with the baseUrl
+                    Location = Uri.IsWellFormedUriString(item.Permalink, UriKind.Absolute) ? item.Permalink : baseUrl + item.Permalink,
                     Priority = item.MetaPriority,
                     TimeStamp = item.LastModified
                 });
@@ -121,7 +122,8 @@ namespace Piranha.AspNetCore
                         urls.Add(new Url
                         {
                             ChangeFrequency = ChangeFrequency.Daily,
-                            Location = baseUrl + post.Permalink,
+                            // If the Permalink contains an absolute Uri (e.g. redirection), don't prefix with the baseUrl
+                            Location = Uri.IsWellFormedUriString(post.Permalink, UriKind.Absolute) ? item.Permalink : baseUrl + post.Permalink,
                             Priority = post.MetaPriority,
                             TimeStamp = post.LastModified
                         });


### PR DESCRIPTION
If the Permalink contains an absolute Uri (usually because of redirection), it should not be prefixed with the baseUrl